### PR TITLE
Fixed and More Consistent Pragmas

### DIFF
--- a/modules/passkey/contracts/4337/SafeWebAuthnSharedSigner.sol
+++ b/modules/passkey/contracts/4337/SafeWebAuthnSharedSigner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0;
+pragma solidity 0.8.24;
 
 import {SignatureValidator} from "../base/SignatureValidator.sol";
 import {ISafe} from "../interfaces/ISafe.sol";

--- a/modules/passkey/contracts/SafeWebAuthnSignerFactory.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSignerFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0;
+pragma solidity 0.8.24;
 
 import {ISafeSignerFactory} from "./interfaces/ISafeSignerFactory.sol";
 import {SafeWebAuthnSignerProxy} from "./SafeWebAuthnSignerProxy.sol";

--- a/modules/passkey/contracts/SafeWebAuthnSignerProxy.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSignerProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 /* solhint-disable no-complex-fallback */
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.20;
 
 import {P256} from "./libraries/WebAuthn.sol";
 

--- a/modules/passkey/contracts/SafeWebAuthnSignerSingleton.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSignerSingleton.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.20;
 
 import {SignatureValidator} from "./base/SignatureValidator.sol";
 import {P256, WebAuthn} from "./libraries/WebAuthn.sol";

--- a/modules/passkey/contracts/base/SignatureValidator.sol
+++ b/modules/passkey/contracts/base/SignatureValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.20;
 
 import {ERC1271} from "../libraries/ERC1271.sol";
 

--- a/modules/passkey/contracts/interfaces/IP256Verifier.sol
+++ b/modules/passkey/contracts/interfaces/IP256Verifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 /* solhint-disable payable-fallback */
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @title P-256 Elliptic Curve Verifier.

--- a/modules/passkey/contracts/interfaces/ISafe.sol
+++ b/modules/passkey/contracts/interfaces/ISafe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.20;
 
 /**
  * @title Safe Smart Account

--- a/modules/passkey/contracts/interfaces/ISafeSignerFactory.sol
+++ b/modules/passkey/contracts/interfaces/ISafeSignerFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.20;
 
 import {P256} from "../libraries/P256.sol";
 

--- a/modules/passkey/contracts/libraries/ERC1271.sol
+++ b/modules/passkey/contracts/libraries/ERC1271.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 /**
  * @title ERC-1271 Magic Values

--- a/modules/passkey/contracts/libraries/P256.sol
+++ b/modules/passkey/contracts/libraries/P256.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IP256Verifier} from "../interfaces/IP256Verifier.sol";
 

--- a/modules/passkey/contracts/libraries/WebAuthn.sol
+++ b/modules/passkey/contracts/libraries/WebAuthn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {P256} from "./P256.sol";
 

--- a/modules/passkey/contracts/test/Benchmarker.sol
+++ b/modules/passkey/contracts/test/Benchmarker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 contract Benchmarker {
     function call(address to, bytes memory data) external returns (uint256 gas, bytes memory returnData) {

--- a/modules/passkey/contracts/test/DummyP256Verifier.sol
+++ b/modules/passkey/contracts/test/DummyP256Verifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 /* solhint-disable no-complex-fallback */
 /* solhint-disable payable-fallback */
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IP256Verifier} from "../interfaces/IP256Verifier.sol";
 

--- a/modules/passkey/contracts/test/TestDependencies.sol
+++ b/modules/passkey/contracts/test/TestDependencies.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 /* solhint-disable no-global-import */
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.20;
 
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import "@account-abstraction/contracts/samples/VerifyingPaymaster.sol";

--- a/modules/passkey/contracts/test/TestP256Lib.sol
+++ b/modules/passkey/contracts/test/TestP256Lib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IP256Verifier, P256} from "../libraries/P256.sol";
 

--- a/modules/passkey/contracts/test/TestSharedWebAuthnSignerAccessor.sol
+++ b/modules/passkey/contracts/test/TestSharedWebAuthnSignerAccessor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {SafeWebAuthnSharedSigner} from "../4337/SafeWebAuthnSharedSigner.sol";
 

--- a/modules/passkey/contracts/test/TestWebAuthnLib.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {P256, WebAuthn} from "../libraries/WebAuthn.sol";
 


### PR DESCRIPTION
This PR changes the pragmas in the passkeys contract to be:
1. More consistent: we use `^0.8.20` everywhere for "non-top-level" contracts. The version was chosen as this it the first version that supports all of the compiler features that we make use of. Notably, we have `@custom:` NatSpec items which are only officially supported as of v0.8.20. The choice to use floating pragmas here is to make using these support contracts easier across other projects (namely, the `WebAuthn` and `P256` libraries are useful outside of this project).
2. Use fixed pragmas for "top-level" contracts that we deploy: - `SafeWebAuthnProxyFactory` - `SafeWebAuthnSharedSigner` - `FCLP256Verifier`

I am aware that Solidity v0.8.20 doesn't play nice with chains like BNB by default, however this can be worked around by explicitly by setting the EVM version target (as we do in this project) and do not believe this is an issue.